### PR TITLE
test(#58): add printing utilities for TestData and children

### DIFF
--- a/libseam_carving/seam_carving/tests/carver_data.hpp
+++ b/libseam_carving/seam_carving/tests/carver_data.hpp
@@ -15,10 +15,23 @@
 #include <gtest/gtest.h>
 
 namespace seam_carving::tests {
-    struct CarverData : TestData {
+    class CarverData : public TestData {
+    public:
         Seam vertical_seam, horizontal_seam;
         cv::Mat remove_vertical_matrix, remove_horizontal_matrix;
         cv::Mat insert_vertical_matrix, insert_horizontal_matrix;
+
+        inline friend std::ostream& operator<<(std::ostream& os, const CarverData& data) {
+            os << PrintWithLabel(data.vertical_seam, "vertical seam") << "\n";
+            os << PrintWithLabel(data.horizontal_seam, "horizontal seam") << "\n";
+
+            os << PrintWithLabel(data.remove_vertical_matrix, "remove vertical matrix") << "\n";
+            os << PrintWithLabel(data.remove_horizontal_matrix, "remove horizontal matrix") << "\n";
+
+            os << PrintWithLabel(data.insert_vertical_matrix, "insert vertical matrix") << "\n";
+            os << PrintWithLabel(data.insert_horizontal_matrix, "insert horizontal matrix");
+            return os;
+        }
     };
 
 

--- a/libseam_carving/seam_carving/tests/carver_data.hpp
+++ b/libseam_carving/seam_carving/tests/carver_data.hpp
@@ -8,6 +8,7 @@
 // project
 #include <seam_carving/seam.hpp>
 #include <seam_carving/tests/test_data.hpp>
+#include <seam_carving/tests/print_utils.hpp>
 
 // 3rd party
 #include <nlohmann/json.hpp>
@@ -22,6 +23,7 @@ namespace seam_carving::tests {
         cv::Mat insert_vertical_matrix, insert_horizontal_matrix;
 
         inline friend std::ostream& operator<<(std::ostream& os, const CarverData& data) {
+            os << "TestId - " << data.test_id << "\n";
             os << PrintWithLabel(data.vertical_seam, "vertical seam") << "\n";
             os << PrintWithLabel(data.horizontal_seam, "horizontal seam") << "\n";
 

--- a/libseam_carving/seam_carving/tests/energy_data.hpp
+++ b/libseam_carving/seam_carving/tests/energy_data.hpp
@@ -14,9 +14,17 @@
 #include <gtest/gtest.h>
 
 namespace seam_carving::tests {
-    struct EnergyData : TestData {
+    class EnergyData : public TestData {
+    public:
         cv::Mat sobel_matrix;
         cv::Mat vertical_map_matrix, horizontal_map_matrix;
+
+        inline friend std::ostream& operator<<(std::ostream& os, const EnergyData& data) {
+            os << PrintWithLabel(data.sobel_matrix, "sobel matrix") << "\n";
+            os << PrintWithLabel(data.vertical_map_matrix, "vertical map") << "\n";
+            os << PrintWithLabel(data.horizontal_map_matrix, "horizontal map");
+            return os;
+        }
     };
 
     class EnergyTest : public testing::TestWithParam<EnergyData> { };

--- a/libseam_carving/seam_carving/tests/energy_data.hpp
+++ b/libseam_carving/seam_carving/tests/energy_data.hpp
@@ -7,6 +7,7 @@
 
 // project
 #include <seam_carving/tests/test_data.hpp>
+#include <seam_carving/tests/print_utils.hpp>
 
 // 3rd party
 #include <nlohmann/json.hpp>
@@ -20,6 +21,7 @@ namespace seam_carving::tests {
         cv::Mat vertical_map_matrix, horizontal_map_matrix;
 
         inline friend std::ostream& operator<<(std::ostream& os, const EnergyData& data) {
+            os << "TestId - " << data.test_id << "\n";
             os << PrintWithLabel(data.sobel_matrix, "sobel matrix") << "\n";
             os << PrintWithLabel(data.vertical_map_matrix, "vertical map") << "\n";
             os << PrintWithLabel(data.horizontal_map_matrix, "horizontal map");

--- a/libseam_carving/seam_carving/tests/json_utils.hpp
+++ b/libseam_carving/seam_carving/tests/json_utils.hpp
@@ -42,7 +42,8 @@ struct adl_serializer<cv::Mat> {
         int rows = j.at("rows"), cols = j.at("cols");
         int type = j.at("type");
         std::vector<int> data = j.at("data");
-        matrix = cv::Mat(rows, cols, type, data.data()).clone();
+        matrix = cv::Mat(rows, cols, CV_32S, data.data()).clone();
+        matrix.convertTo(matrix, type);
 
         // if the matrix only has one channel, convert it to 3
         if (matrix.channels() == 1) {

--- a/libseam_carving/seam_carving/tests/test_data.hpp
+++ b/libseam_carving/seam_carving/tests/test_data.hpp
@@ -5,6 +5,9 @@
 #ifndef SEAM_CARVING_TEST_DATA_HPP
 #define SEAM_CARVING_TEST_DATA_HPP
 
+// project
+#include <seam_carving/tests/print_utils.hpp>
+
 // 3rd party
 #include <nlohmann/json.hpp>
 #include <opencv2/core.hpp>

--- a/libseam_carving/seam_carving/tests/test_data.hpp
+++ b/libseam_carving/seam_carving/tests/test_data.hpp
@@ -14,11 +14,6 @@
 #include <vector>
 
 namespace seam_carving::tests {
-    struct TestData {
-        int test_id;
-        cv::Mat original_matrix;
-    };
-
     /** Path to JSON data file for tests from libseam_carving/ */
     const std::string kJSONDataFile = "tests/data.json";
 
@@ -28,6 +23,18 @@ namespace seam_carving::tests {
         nlohmann::json j = nlohmann::json::parse(file);
         return j;
     }
+
+    class TestData {
+    public:
+        int test_id;
+        cv::Mat original_matrix;
+
+        inline friend std::ostream& operator<<(std::ostream& os, const TestData& data) {
+            os << "TestId - " << data.test_id << "\n";
+            os << PrintWithLabel(data.original_matrix, "original matrix");
+            return os;
+        }
+    };
 }
 
 #endif //SEAM_CARVING_TEST_DATA_HPP

--- a/libseam_carving/tests/unit/carver.test.cpp
+++ b/libseam_carving/tests/unit/carver.test.cpp
@@ -41,7 +41,7 @@ TEST_P(CarverTest, FindVerticalSeamReturnsCorrectSeam) {
 
     /** @TODO(#58): add printing for TestData and children */
     EXPECT_EQ(expected, actual)
-       << "TestId - " << carver_data.test_id;
+       << carver_data;
 }
 
 TEST_P(CarverTest, FindHorizontalSeamReturnsCorrectSeam) {
@@ -54,7 +54,7 @@ TEST_P(CarverTest, FindHorizontalSeamReturnsCorrectSeam) {
     sc::Seam actual = carver.FindHorizontalSeam(input);
 
     EXPECT_EQ(expected, actual)
-        << "TestId - " << carver_data.test_id;
+        << carver_data;
 }
 
 TEST_P(CarverTest, RemoveVerticalSeamReturnsImageWithoutSpecifiedSeam) {
@@ -69,10 +69,7 @@ TEST_P(CarverTest, RemoveVerticalSeamReturnsImageWithoutSpecifiedSeam) {
     carver.RemoveVerticalSeam(seam, input, actual);
 
     EXPECT_TRUE(sct::equalMatrices(expected, actual))
-        << "TestId - " << carver_data.test_id << "\n"
-        << sct::PrintWithLabel(expected, "expected") << "\n"
-        << sct::PrintWithLabel(actual, "actual") << "\n"
-        << sct::PrintWithLabel(seam, "seam");
+        << carver_data;
 }
 
 TEST_P(CarverTest, RemoveHorizontalSeamReturnsImageWithoutSpecifiedSeam) {
@@ -87,10 +84,7 @@ TEST_P(CarverTest, RemoveHorizontalSeamReturnsImageWithoutSpecifiedSeam) {
     carver.RemoveHorizontalSeam(seam, input, actual);
 
     EXPECT_TRUE(sct::equalMatrices(expected, actual))
-        << "TestId - " << carver_data.test_id << "\n"
-        << sct::PrintWithLabel(expected, "expected") << "\n"
-        << sct::PrintWithLabel(actual, "actual") << "\n"
-        << sct::PrintWithLabel(seam, "seam");
+        << carver_data;
 }
 
 

--- a/libseam_carving/tests/unit/carver.test.cpp
+++ b/libseam_carving/tests/unit/carver.test.cpp
@@ -39,7 +39,6 @@ TEST_P(CarverTest, FindVerticalSeamReturnsCorrectSeam) {
 
     sc::Seam actual = carver.FindVerticalSeam(input);
 
-    /** @TODO(#58): add printing for TestData and children */
     EXPECT_EQ(expected, actual)
        << carver_data;
 }

--- a/libseam_carving/tests/unit/energy.test.cpp
+++ b/libseam_carving/tests/unit/energy.test.cpp
@@ -34,9 +34,7 @@ TEST_P(EnergyTest, ComputeVerticalMapReturnsCorrectValue) {
     sce::ComputeVerticalMap(input, actual);
 
     EXPECT_TRUE(sct::equalMatrices(expected, actual))
-                        << "TestId - " << energy_data.test_id << "\n"
-                        << sct::PrintWithLabel(expected, "expected") << "\n"
-        << sct::PrintWithLabel(actual, "actual");
+        << energy_data;
 }
 
 TEST_P(EnergyTest, ComputeHorizontalMapReturnsCorrectValue) {
@@ -49,7 +47,5 @@ TEST_P(EnergyTest, ComputeHorizontalMapReturnsCorrectValue) {
     sce::ComputeHorizontalMap(input, actual);
 
     EXPECT_TRUE(sct::equalMatrices(expected, actual))
-        << "TestId - " << energy_data.test_id << "\n"
-        << sct::PrintWithLabel(expected, "expected") << "\n"
-        << sct::PrintWithLabel(actual, "actual");
+        << energy_data;
 }


### PR DESCRIPTION
Closes #58 

# Changes

- Adds support for the out-stream operator `<<` for `TestData` and its children, `EnergyData` and `CarverData`
- Fixes matrix ingestion from JSON so that the type is properly converted upon read

# Notes
